### PR TITLE
Hide files not owned by dxw

### DIFF
--- a/drivetime.py
+++ b/drivetime.py
@@ -88,7 +88,7 @@ def create_view():
   drive_users LEFT JOIN drive_permissions ON drive_users.permissionId=drive_permissions.id
               LEFT JOIN drive_files ON drive_permissions.fileID=drive_files.id
               LEFT JOIN drive_users AS file_owners ON drive_files._owner=file_owners.permissionId
-  WHERE drive_users.emailAddress NOT LIKE "%dxw.com"
+  WHERE drive_users.emailAddress NOT LIKE "%dxw.com" AND file_owners.emailAddress LIKE "%dxw.com"
   GROUP BY name, drive_users.displayName
   """)
 


### PR DESCRIPTION
We can't do much about the files we don't own, so we hide them from the summary.

bob hasn't actually asked for this, so leaving as an open PR.